### PR TITLE
fix: Correct call log query to prevent crash

### DIFF
--- a/app/src/main/java/com/example/orthowebview/MainActivity.kt
+++ b/app/src/main/java/com/example/orthowebview/MainActivity.kt
@@ -184,12 +184,15 @@ class MainActivity : AppCompatActivity() {
             return null
         }
         val projection = arrayOf(CallLog.Calls.NUMBER, CallLog.Calls.CACHED_NAME)
+        val limitedUri = CallLog.Calls.CONTENT_URI.buildUpon()
+            .appendQueryParameter(CallLog.Calls.LIMIT_PARAM_KEY, "5")
+            .build()
         val cursor = contentResolver.query(
-            CallLog.Calls.CONTENT_URI,
+            limitedUri,
             projection,
             null,
             null,
-            "${CallLog.Calls.DATE} DESC LIMIT 5"
+            "${CallLog.Calls.DATE} DESC"
         )
         cursor?.use {
             val numberColumn = it.getColumnIndexOrThrow(CallLog.Calls.NUMBER)


### PR DESCRIPTION
Fixes a runtime crash (IllegalArgumentException: Invalid token LIMIT) caused by an incorrect database query.

The LIMIT clause was moved from the 'sortOrder' parameter to a URI query parameter (`limit=5`), which is the correct way to limit results from a ContentResolver. This resolves the illegal argument exception that occurred on activity creation.